### PR TITLE
Add <image> SVG element

### DIFF
--- a/contracts/SVG.sol
+++ b/contracts/SVG.sol
@@ -114,6 +114,19 @@ library svg {
         return el('animateTransform', _props, utils.NULL);
     }
 
+    function image(string memory _href, string memory _props)
+        internal
+        pure
+        returns (string memory)
+    {
+        return
+            el(
+                'image',
+                string.concat(prop('href', _href), ' ', _props),
+                utils.NULL
+            );
+    }
+
     /* COMMON */
     // A generic element, can be used to construct any SVG (or HTML) element
     function el(


### PR DESCRIPTION
Add `image()` method to create `<image>` elements in `SVG.sol`.
Only `_href` is a required property in this PR, but possible props include:
- `x`
- `y`
- `width`
- `height`
- `preserveAspectRatio`
- `crossOrigin`

per the [Mozilla documentation](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/image).
Open to working in the others if necessary.

`href` can be either an external URL, or a base64 encoded data URI when keeping data entirely on-chain.