### PR TITLE
Fix tmpdir creation error on Linux in qa script

### DIFF
--- a/src/qa.js
+++ b/src/qa.js
@@ -8,13 +8,14 @@ const deploy = require('./deploy');
 const { DOMParser } = require('xmldom');
 
 const SOURCE = path.join(__dirname, '..', 'contracts', 'Renderer.sol');
+const DESTINATION = path.join(os.tmpdir(), 'hot-chain-svg-');
 
 async function main() {
   const { vm, pk } = await boot();
   const { abi, bytecode } = compile(SOURCE);
   const address = await deploy(vm, pk, bytecode);
 
-  const tempFolder = fs.mkdtempSync(os.tmpdir());
+  const tempFolder = fs.mkdtempSync(DESTINATION);
   console.log('Saving to', tempFolder);
 
   for (let i = 1; i < 256; i++) {


### PR DESCRIPTION
First thanks for the repo & the code 🙌️

Just had this error after executing `yarn qa` on Ubuntu 20:
```
yarn run v1.22.15
$ node src/qa.js
Error: EACCES: permission denied, mkdtemp '/tmpXXXXXX'
    at Object.mkdtempSync (node:fs:2752:3)
    at main (/home/me/projects/workspace_contrib/hot-chain-svg/src/qa.js:17:25) {
  errno: -13,
  syscall: 'mkdtemp',
  code: 'EACCES',
  path: '/tmpXXXXXX'
}
```

So I added a prefix on the tmp folder in `qa.js`.

Feel free to edit my little contribution